### PR TITLE
Update root_check

### DIFF
--- a/res/customconfig/actions/push-actions/root_check
+++ b/res/customconfig/actions/push-actions/root_check
@@ -12,7 +12,8 @@ elif [ -f /system/xbin/su ] && [ -f /data/app/*uper?ser.apk ]; then
 	echo "You have full working ROOT Installed!";
 elif [ -f /system/xbin/su ] && [ -f /data/app/Superuser.apk ]; then
 	echo "You have full working ROOT Installed!";
+elif [ -x /systemc/xbin/su ] && [ -u /systemc/xbin/su ]; then
+	echo "You have working ROOT Installed!!";
 else
 	echo "You don't have ROOT installed!";
 fi;
-


### PR DESCRIPTION
In rootbox >3.9, we use the opensource su binary. The SuperUser app is integrated in ROM, so SuperUser from Chainfire is not needed anymore.
If the user has the root binary installed and it is executable and has SUID bit set, then the phone is rooted. It's just a problem of what app uses the binary, but the phone is considered to be rooted since su command will not fail. :)

And maybe we don't need to check for SuperSU anymore, but I don't want to mess with your work.
