### PR TITLE
Add forgotten -w 1023 to fuse_sdcard1 in init.smdk4210.rc

### DIFF
--- a/res/misc/KitKat-CM-AOKP-11/init.smdk4210.rc
+++ b/res/misc/KitKat-CM-AOKP-11/init.smdk4210.rc
@@ -399,7 +399,7 @@ service fuse_sdcard0 /system/bin/sdcard -u 1023 -g 1023 /mnt/media_rw/sdcard0 /s
     class late_start
     disabled
 
-service fuse_sdcard1 /system/bin/sdcard -u 1023 -g 1023 /mnt/media_rw/sdcard1 /storage/sdcard1
+service fuse_sdcard1 /system/bin/sdcard -u 1023 -g 1023 -w 1023 /mnt/media_rw/sdcard1 /storage/sdcard1
     class late_start
     disabled
 


### PR DESCRIPTION
I added this because it may fix fuse issue in kk roms it's from xLaMbChOpSx patch in slimkat repo.
If you forget to add it here's a easy way to add ;)
